### PR TITLE
Fix lora weight fetch in isSameBatch, in viewer.html

### DIFF
--- a/viewer.html
+++ b/viewer.html
@@ -1527,10 +1527,10 @@ File Version 2024-02-19/A1
         const [aLoRAKeys, bLoRAKeys] = [a, b].map((item) =>
           Object.keys(item).filter((key) => key.startsWith("LoRA ["))
         );
-        const [aLoRAs, bLoRAs] = [aLoRAKeys, bLoRAKeys].map((keys) =>
+        const [aLoRAs, bLoRAs] = [{obj: a, keys: aLoRAKeys}, {obj: b, keys: bLoRAKeys}].map(({obj, keys}) =>
           keys.map((key) => {
             const LoRAName = key.split("]")[0].replace("[", "");
-            const LoRAWeight = a[key];
+            const LoRAWeight = obj[key];
             return { LoRAName, LoRAWeight };
           })
         );


### PR DESCRIPTION
In the 'viewer.html' file, this update corrects the comparison of 'lora' weight by fetching it from the correct object. Previously, regardless of the object in context, the weight was being fetched inappropriately solely from object 'a'. This might have resulted in inaccurate comparisons when the source object should have been 'b'.