### PR TITLE
Add CSS style for style image sizing in viewer.html

### DIFF
--- a/viewer.html
+++ b/viewer.html
@@ -2504,6 +2504,9 @@ File Version 2024-02-19/A1
         div.styleContainer {
           position: relative;
         }
+        img.styleImage {
+          width: 128px; /* same width as title */
+        }
         span.styleTitle {
           position:absolute;
           top:92px;


### PR DESCRIPTION
The CSS code in viewer.html has been updated to include a new style definition for style images. This ensures all images maintain a consistent width (the same width as the title element) to make styles readable.

when custom styles have no images it was cluttered like this:
![image](https://github.com/toutjavascript/Fooocus-Log-Viewer/assets/273573/51f07c91-a147-4420-8f5e-70e8acd5a0ea)

after suggested changes it will be:
![image](https://github.com/toutjavascript/Fooocus-Log-Viewer/assets/273573/c9f1a155-aff0-4c91-a359-09202b9380c9)